### PR TITLE
chore: replace `as` with `AS`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22 as builder
+FROM golang:1.22 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
GitHubのCIログで以下指摘があった
https://docs.docker.com/go/dockerfile/rule/from-as-casing/
https://github.com/GiganticMinecraft/seichi-gateway-operator/pull/21/files