### PR TITLE
fix: Fix image registry for kube-rbac-proxy

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -15,7 +15,7 @@ spec:
           capabilities:
             drop:
               - "ALL"
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.1
+        image: mirror.gcr.io/kubebuilder/kube-rbac-proxy:v0.14.1
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
`seichi-gateway-operator-controller-manager`のPod（`seichi-gateway-operator-controller-manager-6f996c54f6-jncb9`）が、以下エラーにより`ImagePullBackOff`で止まっていたので、https://github.com/GiganticMinecraft/seichi_infra/issues/3234 を参照して、レジストリを`mirror.gcr.io`に切り替えました。

> rpc error: code = NotFound desc = failed to pull and unpack image "gcr.io/kubebuilder/kube-rbac-proxy:v0.14.1": failed to resolve image: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.1: not found